### PR TITLE
document behavior of ->all in scalar context

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Path-Iterator-Rule
 
 {{$NEXT}}
 
+    [DOCS]
+
+    - Document the behavior of ->all in scalar context
+
 1.006     2013-10-09 11:14:28 America/New_York
 
     [PREREQS]

--- a/pod/lib/Path/Iterator/Rule.pm
+++ b/pod/lib/Path/Iterator/Rule.pm
@@ -91,6 +91,8 @@ Returns a list of paths that match the rule.  It takes the same arguments and
 has the same behaviors as the C<iter> method.  The C<all> method uses C<iter>
 internally to fetch all results.
 
+In scalar context, it will return the count of matched paths.
+
 In void context, it is optimized to iterate over everything, but not store
 results.  This is most useful with the C<visitor> option:
 

--- a/t/basic.t
+++ b/t/basic.t
@@ -42,6 +42,8 @@ require_ok('Path::Iterator::Rule');
 
     is( scalar @files, 3, "All files" ) or diag explain \@files;
 
+    is( $rule->all($td), 3, "All files (->all in scalar context)");
+
     $rule  = Path::Iterator::Rule->new->dir;
     @files = ();
     @files = map { "$_" } $rule->all($td);


### PR DESCRIPTION
This just documents that ->all in scalar context will continue to return a count.  At the moment, it's just an implementation detail.
