### PR TITLE
in breadth-first traversals, don't scan a directory until its contents are examine

### DIFF
--- a/lib/Path/Iterator/Rule.pm
+++ b/lib/Path/Iterator/Rule.pm
@@ -222,7 +222,6 @@ sub _iter {
                 $stash->{_depth} = $depth;
                 $opt_visitor->( $item, $base, $stash );
             }
-            $DB::single=1;
 
             # if it's a directory, maybe add children to the queue
             if (   ( -d $string_item )

--- a/lib/Path/Iterator/Rule.pm
+++ b/lib/Path/Iterator/Rule.pm
@@ -179,6 +179,10 @@ sub _iter {
 
     return sub {
         LOOP: {
+              if ( ref $queue[0] eq 'CODE' ) {
+                  unshift @queue, shift(@queue)->();
+                  redo LOOP;
+              }
             my ( $item, $base, $depth, $origin ) = splice( @queue, 0, 4 );
             return unless $item;
             return $item->[0] if ref $item eq 'ARRAY'; # deferred for postorder
@@ -218,6 +222,7 @@ sub _iter {
                 $stash->{_depth} = $depth;
                 $opt_visitor->( $item, $base, $stash );
             }
+            $DB::single=1;
 
             # if it's a directory, maybe add children to the queue
             if (   ( -d $string_item )
@@ -230,31 +235,34 @@ sub _iter {
                 else {
                     my @next;
                     my $depth_p1 = $depth + 1;
+                    my $next;
                     if ($can_children) {
-                        my @paths = $can_children->( $self, $item );
-                        if ($opt_sorted) {
-                            @paths = sort { "$a->[0]" cmp "$b->[0]" } @paths;
-                        }
-                        @next = map { ( $_->[1], $_->[0], $depth_p1, $origin ) } @paths;
+                        $next = sub {
+                            my @paths = $can_children->( $self, $item );
+                            if ($opt_sorted) {
+                                @paths = sort { "$a->[0]" cmp "$b->[0]" } @paths;
+                            }
+                            map { ( $_->[1], $_->[0], $depth_p1, $origin ) } @paths;
+                        };
                     }
                     else {
+                        $next = sub {
                         opendir( my $dh, $string_item );
                         if ($opt_sorted) {
-                            @next =
                               map { ( "$string_item/$_", $_, $depth_p1, $origin ) }
                               sort { $a cmp $b } grep { $_ ne "." && $_ ne ".." } readdir $dh;
                         }
                         else {
-                            @next =
                               map { ( "$string_item/$_", $_, $depth_p1, $origin ) }
                               grep { $_ ne "." && $_ ne ".." } readdir $dh;
                         }
+                    };
                     }
 
                     if ($opt_depthfirst) {
                         # for postorder, requeue as reference to signal it can be returned
                         # without being retested
-                        push @next,
+                        unshift @queue, 
                           [
                             (
                                   $opt_relative
@@ -264,11 +272,11 @@ sub _iter {
                           ],
                           $base, $depth, $origin
                           if $interest && $opt_depthfirst > 0;
-                        unshift @queue, @next;
+                        unshift @queue, $next;
                         redo LOOP if $opt_depthfirst > 0;
                     }
                     else {
-                        push @queue, @next;
+                        push @queue, $next;
                     }
                 }
             }

--- a/t/children-order.t
+++ b/t/children-order.t
@@ -1,0 +1,109 @@
+use 5.006;
+use strict;
+use warnings;
+use Test::More 0.92;
+use File::Temp;
+use Test::Deep qw/cmp_deeply/;
+use File::pushd qw/pushd/;
+
+use lib 't/lib';
+use PCNTest;
+
+use Path::Iterator::Rule;
+
+{
+
+    package CheckOrder;
+
+    use parent 'Path::Iterator::Rule';
+    use PCNTest;
+
+    our $order;
+    our $td;
+
+    sub new {
+      ( my $class, $td, $order ) = @_;
+      $class->SUPER::new();
+    }
+
+    sub _children {
+        my $self = shift;
+        my $path = "" . shift;
+
+        push @$order, 'children:'. unixify( $path, $td );
+
+        opendir( my $dh, $path );
+        return map { [ $_, "$path/$_" ] }
+          grep { $_ ne "." && $_ ne ".." } readdir $dh;
+    }
+
+}
+
+#--------------------------------------------------------------------------#
+
+{
+    my @tree = qw(
+      aaaa.txt
+      bbbb.txt
+      cccc/dddd.txt
+      cccc/eeee/ffff.txt
+      gggg.txt
+    );
+
+    my @breadth = qw(
+      visit:.
+      children:.
+      visit:aaaa.txt
+      visit:bbbb.txt
+      visit:cccc
+      visit:gggg.txt
+      children:cccc
+      visit:cccc/dddd.txt
+      visit:cccc/eeee
+      children:cccc/eeee
+      visit:cccc/eeee/ffff.txt
+    );
+
+    my @depth_pre = qw(
+      visit:.
+      children:.
+      visit:aaaa.txt
+      visit:bbbb.txt
+      visit:cccc
+      children:cccc
+      visit:cccc/dddd.txt
+      visit:cccc/eeee
+      children:cccc/eeee
+      visit:cccc/eeee/ffff.txt
+      visit:gggg.txt
+    );
+
+    my $td = make_tree(@tree);
+
+    my ( $iter, @order );
+    my $rule = CheckOrder->new( $td, \@order );
+
+    @order = ();
+    my $visitor = sub {
+        push @order, 'visit:'.unixify($_, $td);
+    };
+    
+    $rule->all( { depthfirst => 0, visitor => $visitor  }, $td );
+    cmp_deeply( \@order, \@breadth, "Breadth first iteration" )
+      or diag explain \@order;
+
+    @order = ();
+    $rule->all( { depthfirst => -1, visitor => $visitor }, $td );
+    cmp_deeply( \@order, \@depth_pre, "Depth first iteration (pre)" )
+      or diag explain \@order;
+
+    @order = ();
+    $rule->all( { depthfirst => 1, visitor => $visitor }, $td );
+
+    # post and pre have same visit/children pattern
+    cmp_deeply( \@order, \@depth_pre, "Depth first iteration (post)" )
+      or diag explain \@order;
+}
+
+done_testing;
+# COPYRIGHT


### PR DESCRIPTION
See #20

In a breadth-first traversal a directory's children are determined
directly after visiting the directory entry, even if they are not the
next entries to be visited.  If the traversal were to be aborted
prior to visting the directory's children, then scanning the directory
is a waste.  For example, if the directory structure is

p/a
p/a/1
p/b
p/b/2
p/c
p/c/3

The current code results in a visit/find-children pattern of:

visit: .
find children: .
visit: ./p
find children: ./p
visit: ./p/a
find children: ./p/a
visit: ./p/b
find children: ./p/b
visit: ./p/c
find children: ./p/c
visit: ./p/a/1
visit: ./p/b/2
visit: ./p/c/3

Note that the children of all of p/a, p/b, and p/c are determined prior to
descending into p/a.  If the search is aborted whle in p/a, the scans of p/b and p/c are wasted.

This patch delays the scanning of a directory until its children are
requested.  This results in a visit/find-children pattern of

visit: .
find children: .
visit: ./p
find children: ./p
visit: ./p/a
visit: ./p/b
visit: ./p/c
find children: ./p/a
visit: ./p/a/1
find children: ./p/b
visit: ./p/b/2
find children: ./p/c
visit: ./p/c/3

which ensures that if the search is aborted at ./p/a/1, the
unnecessary scanning of ./p/b and ./p/c is avoided.

It does this by pushing closures which perform directory scans onto
the queue of entries to be examined. The closures are evaluated when
they are the next-in-line elements to be examined, thus preventing
premature effort.